### PR TITLE
Key editable view

### DIFF
--- a/plugin-src/code.ts
+++ b/plugin-src/code.ts
@@ -8,6 +8,12 @@ import {
   PostToUIMessage,
 } from "../shared-src/messages";
 import {
+  persistInFigma,
+  PLUGIN_RELAUNCH_KEY_REVIEW_REVISION,
+  readPersistedData,
+  updateNodeKey,
+} from "./pluginDataUtils";
+import {
   csvNodeProcessor,
   csvNodeUpdater,
   csvResultTransformer,
@@ -16,9 +22,9 @@ import {
 } from "./processors/csvProcessor";
 import {
   DEFAULT_HEADING_SETTINGS,
-  persistInFigma,
-  PLUGIN_RELAUNCH_KEY_REVIEW_REVISION,
-  readPersistedData,
+  focusNode,
+  scanTextNodesInfo,
+  sendTextNodesInfoToUI,
   sortNodeByPosition,
 } from "./utils";
 
@@ -36,6 +42,14 @@ figma.ui.onmessage = async (msg: PostToFigmaMessage) => {
     if (msg.persistInFigma) {
       persistDataInFigma();
     }
+  } else if (msg.type === "focus-node") {
+    focusNode(msg.id);
+  } else if (msg.type === "scan-text-node-info") {
+    const nodesInfo = await scanTextNodesInfo();
+    // console.log({ nodesInfo });
+    sendTextNodesInfoToUI(nodesInfo);
+  } else if (msg.type === "update-node-key") {
+    updateNodeKey(msg.nodeId, msg.key);
   }
 };
 

--- a/plugin-src/code.ts
+++ b/plugin-src/code.ts
@@ -45,7 +45,7 @@ figma.ui.onmessage = async (msg: PostToFigmaMessage) => {
   } else if (msg.type === "focus-node") {
     focusNode(msg.id);
   } else if (msg.type === "scan-text-node-info") {
-    const nodesInfo = await scanTextNodesInfo();
+    const nodesInfo = await scanTextNodesInfo(msg.autoTrigger);
     // console.log({ nodesInfo });
     sendTextNodesInfoToUI(nodesInfo);
   } else if (msg.type === "update-node-key") {

--- a/plugin-src/code.ts
+++ b/plugin-src/code.ts
@@ -50,6 +50,10 @@ figma.ui.onmessage = async (msg: PostToFigmaMessage) => {
     sendTextNodesInfoToUI(nodesInfo);
   } else if (msg.type === "update-node-key") {
     updateNodeKey(msg.nodeId, msg.key);
+    figma.ui.postMessage({
+      type: "partial-update-text-node-info-result",
+      partialTextNodesInfo: [{ id: msg.nodeId, key: msg.key }],
+    } as PostToUIMessage);
   }
 };
 

--- a/plugin-src/pluginDataUtils.ts
+++ b/plugin-src/pluginDataUtils.ts
@@ -1,0 +1,50 @@
+export const PLUGIN_DATA_SHARED_NAMESPACE = "CONTENT_COPY";
+export const PLUGIN_DATA_KEY_PERSISTED_DATA = "PERSISTED_DATA";
+export const PLUGIN_RELAUNCH_KEY_REVIEW_REVISION = "review-revision";
+
+export const PLUGIN_DATA_NODE_KEY_KEY = "NODE_KEY";
+
+export const getNodeKey = (node: TextNode): string => {
+  const pluginData = node.getSharedPluginData(
+    PLUGIN_DATA_SHARED_NAMESPACE,
+    PLUGIN_DATA_NODE_KEY_KEY
+  );
+  if (pluginData) {
+    return pluginData;
+  } else {
+    return "";
+  }
+};
+
+export const writeNodeKey = (node: TextNode, key: string) => {
+  node.setSharedPluginData(
+    PLUGIN_DATA_SHARED_NAMESPACE,
+    PLUGIN_DATA_NODE_KEY_KEY,
+    key
+  );
+};
+
+export const updateNodeKey = (id: string, key: string) => {
+  const nodeToFind = figma.root.findOne((x) => x.id === id);
+  if (nodeToFind) {
+    writeNodeKey(nodeToFind as any, key);
+  }
+};
+
+export const persistInFigma = (data: string) => {
+  console.log("persistInFigma", data);
+  figma.root.setSharedPluginData(
+    PLUGIN_DATA_SHARED_NAMESPACE,
+    PLUGIN_DATA_KEY_PERSISTED_DATA,
+    data
+  );
+};
+
+export const readPersistedData = () => {
+  const persistedData = figma.root.getSharedPluginData(
+    PLUGIN_DATA_SHARED_NAMESPACE,
+    PLUGIN_DATA_KEY_PERSISTED_DATA
+  );
+  console.log("readPersistedData", persistedData);
+  return persistedData;
+};

--- a/plugin-src/pluginDataUtils.ts
+++ b/plugin-src/pluginDataUtils.ts
@@ -25,6 +25,7 @@ export const writeNodeKey = (node: TextNode, key: string) => {
 };
 
 export const updateNodeKey = (id: string, key: string) => {
+  //   console.log("updateNodeKey", { id, key });
   const nodeToFind = figma.root.findOne((x) => x.id === id);
   if (nodeToFind) {
     writeNodeKey(nodeToFind as any, key);

--- a/plugin-src/processors/csvProcessor.ts
+++ b/plugin-src/processors/csvProcessor.ts
@@ -19,6 +19,7 @@ import {
   UpdaterSettings,
 } from "./iterate";
 import { unparse, parse } from "papaparse";
+import { convertToCsvDataUri } from "../../shared-src/export-utils";
 
 const getListOption = (node: TextNode): string => {
   const fullListOption = node.getRangeListOptions(0, node.characters.length);
@@ -105,8 +106,7 @@ export const csvResultTransformer = async (
 ): Promise<string> => {
   const rows = resultsPerNode.flatMap((x) => x.results);
   console.log("csvResultTransformer rows", rows);
-  const rowsString = unparse(rows, { header: true });
-  return "data:text/csv;charset=utf-8," + encodeURIComponent(rowsString);
+  return convertToCsvDataUri(rows);
 };
 
 export const parseCsvString = <T extends CsvNodeInfo>(input: string) => {

--- a/plugin-src/processors/textNodeInfoProcessor.ts
+++ b/plugin-src/processors/textNodeInfoProcessor.ts
@@ -1,0 +1,54 @@
+import { TextNodeInfo } from "../../shared-src";
+import { getNodeKey } from "../pluginDataUtils";
+import { sortNodeByPosition } from "../utils";
+import { iterate } from "./iterate";
+
+export const textNodeInfoTextNodeProcess = (
+  node: TextNode,
+  settings: any
+): TextNodeInfo[] => {
+  if (!node.visible || node.characters.length === 0) {
+    return [];
+  }
+
+  const key = getNodeKey(node);
+
+  const nodeInfo = {
+    id: node.id,
+    key,
+    name: node.name,
+    characters: node.characters,
+  };
+  return [nodeInfo];
+};
+
+export const textNodeInfoChildrenNodeProcess = (
+  node: SceneNode & ChildrenMixin,
+  settings: any,
+  processors: any
+): TextNodeInfo[] => {
+  return node.children
+    .slice()
+    .sort(sortNodeByPosition)
+    .reduce<TextNodeInfo[]>((prev, child) => {
+      return [
+        ...prev,
+        ...(iterate<TextNodeInfo[]>(child, settings, processors) || []),
+      ];
+    }, []);
+};
+
+const emptyProcess = () => null;
+
+export const textNodeInfoProcessor = async (
+  node: SceneNode,
+  settings: any
+): Promise<TextNodeInfo[]> => {
+  return (
+    iterate<TextNodeInfo[]>(node, settings, {
+      image: emptyProcess,
+      text: textNodeInfoTextNodeProcess,
+      children: textNodeInfoChildrenNodeProcess,
+    }) || []
+  );
+};

--- a/plugin-src/utils.ts
+++ b/plugin-src/utils.ts
@@ -88,9 +88,11 @@ export const setRelaunchButton = (node: SceneNode) => {
   node.setRelaunchData({ [PLUGIN_RELAUNCH_KEY_REVIEW_REVISION]: "" });
 };
 
-export async function scanTextNodesInfo() {
+export async function scanTextNodesInfo(autoTrigger: boolean) {
   if (figma.currentPage.selection.length === 0) {
-    figma.notify(`Please select something for scanning`);
+    if (!autoTrigger) {
+      figma.notify(`Please select something for scanning`);
+    }
     return [];
   }
 

--- a/shared-src/export-utils.ts
+++ b/shared-src/export-utils.ts
@@ -1,0 +1,13 @@
+import { unparse, parse } from "papaparse";
+
+export const convertToCsvDataUri = <T extends unknown[]>(data: T): string => {
+  const rowsString = unparse(data, { header: true });
+  return "data:text/csv;charset=utf-8," + encodeURIComponent(rowsString);
+};
+
+export const convertToJsonDataUri = <T extends unknown[]>(data: T): string => {
+  return (
+    "data:application/json;charset=utf-8," +
+    encodeURIComponent(JSON.stringify(data))
+  );
+};

--- a/shared-src/messages.ts
+++ b/shared-src/messages.ts
@@ -65,10 +65,16 @@ export type ScanTextNodeInfoResultToUIMessage = {
   textNodesInfo: TextNodeInfo[];
 };
 
+export type PartialUpdateTextNodeInfoResultToUIMessage = {
+  type: "partial-update-text-node-info-result";
+  partialTextNodesInfo: Partial<TextNodeInfo>[];
+};
+
 export type PostToUIMessage =
   | FileGeneratedToUIMessage
   | AvailableLangFromCsvToUIMessage
-  | ScanTextNodeInfoResultToUIMessage;
+  | ScanTextNodeInfoResultToUIMessage
+  | PartialUpdateTextNodeInfoResultToUIMessage;
 
 // This is useful to run some code when react is finished to get new information from Figma
 export type UiFinishLoadingToFigmaMessage = {

--- a/shared-src/messages.ts
+++ b/shared-src/messages.ts
@@ -60,6 +60,10 @@ export type TextNodeInfo = {
   characters: string;
 };
 
+export type SelectableTextNodeInfo = TextNodeInfo & {
+  checked: boolean;
+};
+
 export type ScanTextNodeInfoResultToUIMessage = {
   type: "scan-text-node-info-result";
   textNodesInfo: TextNodeInfo[];
@@ -98,6 +102,7 @@ export type UpdateContentWithLangToFigmaMessage = {
 
 export type ScanTextNodeInfoToFigmaMessage = {
   type: "scan-text-node-info";
+  autoTrigger: boolean;
 };
 
 export type FocusNodeToFigmaMessage = {

--- a/shared-src/messages.ts
+++ b/shared-src/messages.ts
@@ -50,9 +50,25 @@ export type AvailableLangFromCsvToUIMessage = {
   langs: string[];
 };
 
+export type TextNodeInfo = {
+  /** Figma Node ID */
+  id: string;
+  /** User defined node key */
+  key: string;
+  /** Figma Node name */
+  name: string;
+  characters: string;
+};
+
+export type ScanTextNodeInfoResultToUIMessage = {
+  type: "scan-text-node-info-result";
+  textNodesInfo: TextNodeInfo[];
+};
+
 export type PostToUIMessage =
   | FileGeneratedToUIMessage
-  | AvailableLangFromCsvToUIMessage;
+  | AvailableLangFromCsvToUIMessage
+  | ScanTextNodeInfoResultToUIMessage;
 
 // This is useful to run some code when react is finished to get new information from Figma
 export type UiFinishLoadingToFigmaMessage = {
@@ -74,8 +90,26 @@ export type UpdateContentWithLangToFigmaMessage = {
   persistInFigma: boolean;
 };
 
+export type ScanTextNodeInfoToFigmaMessage = {
+  type: "scan-text-node-info";
+};
+
+export type FocusNodeToFigmaMessage = {
+  type: "focus-node";
+  id: string;
+};
+
+export type UpdateNodeKeyToFigmaMessage = {
+  type: "update-node-key";
+  nodeId: string;
+  key: string;
+};
+
 export type PostToFigmaMessage =
   | UiFinishLoadingToFigmaMessage
   | ExportCsvFileToFigmaMessage
   | DetectAvailableLangFromCSVToFigmaMessage
-  | UpdateContentWithLangToFigmaMessage;
+  | UpdateContentWithLangToFigmaMessage
+  | ScanTextNodeInfoToFigmaMessage
+  | FocusNodeToFigmaMessage
+  | UpdateNodeKeyToFigmaMessage;

--- a/ui-src/App.css
+++ b/ui-src/App.css
@@ -20,8 +20,6 @@ body {
 
 .appRoot.appRoot {
   background: var(--salt-container-primary-background);
-  /* Vertical align */
-  justify-content: center;
 }
 
 .language-formField {

--- a/ui-src/App.tsx
+++ b/ui-src/App.tsx
@@ -2,7 +2,7 @@ import { SaltProvider } from "@salt-ds/core";
 import React, { useEffect } from "react";
 import { PostToFigmaMessage } from "../shared-src";
 import { useFigmaPluginTheme } from "./components/useFigmaPluginTheme";
-import { MainView } from "./view/MainView";
+import { TabsView } from "./view/TabsView";
 
 import "./App.css";
 
@@ -22,7 +22,7 @@ function App() {
 
   return (
     <SaltProvider mode={theme}>
-      <MainView />
+      <TabsView />
     </SaltProvider>
   );
 }

--- a/ui-src/__tests__/SimpleView.spec.tsx
+++ b/ui-src/__tests__/SimpleView.spec.tsx
@@ -1,12 +1,12 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvents from "@testing-library/user-event";
 import React from "react";
-import { MainView } from "../view/MainView";
+import { SimpleView } from "../view/SimpleView";
 
-describe("MainView", () => {
+describe("SimpleView", () => {
   beforeEach(() => {
     window.parent.postMessage = jest.fn();
-    render(<MainView />);
+    render(<SimpleView />);
   });
   test("renders export button", () => {
     expect(screen.getByText("Export CSV")).toBeInTheDocument();

--- a/ui-src/components/NodeKeyInput.tsx
+++ b/ui-src/components/NodeKeyInput.tsx
@@ -1,0 +1,29 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Input } from "@salt-ds/lab";
+import { TextNodeInfo } from "../../shared-src";
+import { Button } from "@salt-ds/core";
+import { CloseSmallIcon, WarningIcon } from "@salt-ds/icons";
+
+export const NodeKeyInput = ({
+  nodeInfo,
+  onUpdateNodeKey,
+}: {
+  nodeInfo: TextNodeInfo;
+  onUpdateNodeKey: (id: string, key: string) => void;
+}) => {
+  // TODO: update key when blur out of the input or hit "Enter" key
+  return (
+    <Input
+      value={nodeInfo.key || nodeInfo.name}
+      endAdornment={
+        nodeInfo.key ? (
+          <Button onClick={() => onUpdateNodeKey(nodeInfo.id, "")}>
+            <CloseSmallIcon />
+          </Button>
+        ) : (
+          <WarningIcon />
+        )
+      }
+    />
+  );
+};

--- a/ui-src/components/NodeKeyInput.tsx
+++ b/ui-src/components/NodeKeyInput.tsx
@@ -14,6 +14,8 @@ export const NodeKeyInput = ({
   console.log("NodeKeyInput nodeInfo", nodeInfo);
   return (
     <Input
+      // Use `key` to force rerender a new Input when nodeInfo key changes
+      key={`input-${nodeInfo.key}`}
       defaultValue={nodeInfo.key}
       inputProps={{ placeholder: nodeInfo.name }}
       endAdornment={

--- a/ui-src/components/NodeKeyInput.tsx
+++ b/ui-src/components/NodeKeyInput.tsx
@@ -11,10 +11,11 @@ export const NodeKeyInput = ({
   nodeInfo: TextNodeInfo;
   onUpdateNodeKey: (id: string, key: string) => void;
 }) => {
-  // TODO: update key when blur out of the input or hit "Enter" key
+  console.log("NodeKeyInput nodeInfo", nodeInfo);
   return (
     <Input
-      value={nodeInfo.key || nodeInfo.name}
+      defaultValue={nodeInfo.key}
+      inputProps={{ placeholder: nodeInfo.name }}
       endAdornment={
         nodeInfo.key ? (
           <Button onClick={() => onUpdateNodeKey(nodeInfo.id, "")}>
@@ -24,6 +25,10 @@ export const NodeKeyInput = ({
           <WarningIcon />
         )
       }
+      onBlur={(e) => {
+        const updatedValue = e.currentTarget.value;
+        onUpdateNodeKey(nodeInfo.id, updatedValue);
+      }}
     />
   );
 };

--- a/ui-src/view/AdvancedView.css
+++ b/ui-src/view/AdvancedView.css
@@ -1,0 +1,10 @@
+.advanced-view {
+  padding: var(--salt-size-unit);
+}
+
+.advanced-view table,
+.advanced-view th,
+.advanced-view td {
+  border: 1px solid var(--salt-separable-tertiary-borderColor);
+  border-collapse: collapse;
+}

--- a/ui-src/view/AdvancedView.css
+++ b/ui-src/view/AdvancedView.css
@@ -1,5 +1,12 @@
 .advanced-view {
   padding: var(--salt-size-unit);
+  flex-grow: 1;
+  min-height: 0;
+}
+
+.advanced-view .tableWrapper {
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .advanced-view table,

--- a/ui-src/view/AdvancedView.css
+++ b/ui-src/view/AdvancedView.css
@@ -8,3 +8,8 @@
   border: 1px solid var(--salt-separable-tertiary-borderColor);
   border-collapse: collapse;
 }
+
+.advanced-view .tableCheckbox.saltCheckbox {
+  --checkbox-label-marginTop: 0;
+  width: 14px;
+}

--- a/ui-src/view/AdvancedView.tsx
+++ b/ui-src/view/AdvancedView.tsx
@@ -1,0 +1,133 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Button, FlexLayout, StackLayout } from "@salt-ds/core";
+import { Checkbox, Input } from "@salt-ds/lab";
+import {
+  PostToFigmaMessage,
+  PostToUIMessage,
+  TextNodeInfo,
+} from "../../shared-src";
+import { CloseSmallIcon, TargetIcon, WarningIcon } from "@salt-ds/icons";
+
+import "./AdvancedView.css";
+import { NodeKeyInput } from "../components/NodeKeyInput";
+
+export const AdvancedView = () => {
+  const [textNodesInfo, setTextNodesInfo] = useState<TextNodeInfo[]>([
+    // {
+    //   id: "101:4",
+    //   key: "Heading",
+    //   characters: "Heading v2",
+    // },
+  ]);
+
+  const handleWindowMessage = useCallback(
+    (event: {
+      data: {
+        pluginMessage: PostToUIMessage;
+      };
+    }) => {
+      if (event.data.pluginMessage) {
+        const { pluginMessage } = event.data;
+        switch (pluginMessage.type) {
+          case "scan-text-node-info-result": {
+            const { textNodesInfo } = pluginMessage;
+            setTextNodesInfo(textNodesInfo);
+            break;
+          }
+          default:
+        }
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    window.addEventListener("message", handleWindowMessage);
+    return () => {
+      window.removeEventListener("message", handleWindowMessage);
+    };
+  }, [handleWindowMessage]);
+
+  const onScanClick = () => {
+    parent.postMessage(
+      {
+        pluginMessage: {
+          type: "scan-text-node-info",
+        } as PostToFigmaMessage,
+      },
+      "*"
+    );
+  };
+
+  const onFocusTextNode = (id: string) => {
+    parent.postMessage(
+      {
+        pluginMessage: {
+          type: "focus-node",
+          id,
+        } as PostToFigmaMessage,
+      },
+      "*"
+    );
+  };
+
+  const onUpdateNodeKey = (id: string, key: string) => {
+    parent.postMessage(
+      {
+        pluginMessage: {
+          type: "update-node-key",
+          nodeId: id,
+          key,
+        } as PostToFigmaMessage,
+      },
+      "*"
+    );
+  };
+
+  return (
+    <StackLayout className="advanced-view">
+      <FlexLayout>
+        <Button onClick={onScanClick}>Scan</Button>
+        <Checkbox label="Hide duplicate" disabled />
+      </FlexLayout>
+      <table>
+        <thead>
+          <tr>
+            <th>
+              <Checkbox />
+            </th>
+            <th>Key</th>
+            <th>Characters</th>
+            <th>{/* Button column */}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {/* Each row */}
+          {textNodesInfo.map((nodeInfo) => {
+            return (
+              <tr>
+                <th>
+                  <Checkbox />
+                </th>
+                <td>
+                  <NodeKeyInput
+                    nodeInfo={nodeInfo}
+                    onUpdateNodeKey={onUpdateNodeKey}
+                  />
+                </td>
+                <td>
+                  <Input value={nodeInfo.characters} readOnly />
+                </td>
+                <td>
+                  <Button onClick={() => onFocusTextNode(nodeInfo.id)}>
+                    <TargetIcon />
+                  </Button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </StackLayout>
+  );
+};

--- a/ui-src/view/AdvancedView.tsx
+++ b/ui-src/view/AdvancedView.tsx
@@ -34,6 +34,20 @@ export const AdvancedView = () => {
             setTextNodesInfo(textNodesInfo);
             break;
           }
+          case "partial-update-text-node-info-result": {
+            const { partialTextNodesInfo: updatedInfo } = pluginMessage;
+            setTextNodesInfo((prev) =>
+              prev.map((info) => {
+                const matchedInfo = updatedInfo.find((x) => x.id === info.id);
+                if (matchedInfo) {
+                  return { ...info, ...matchedInfo };
+                } else {
+                  return info;
+                }
+              })
+            );
+            break;
+          }
           default:
         }
       }
@@ -58,6 +72,11 @@ export const AdvancedView = () => {
       "*"
     );
   };
+
+  // Auto scan on UI load
+  useEffect(() => {
+    onScanClick();
+  }, []);
 
   const onFocusTextNode = (id: string) => {
     parent.postMessage(
@@ -94,7 +113,7 @@ export const AdvancedView = () => {
         <thead>
           <tr>
             <th>
-              <Checkbox />
+              <Checkbox className="tableCheckbox" />
             </th>
             <th>Key</th>
             <th>Characters</th>
@@ -107,7 +126,7 @@ export const AdvancedView = () => {
             return (
               <tr>
                 <th>
-                  <Checkbox />
+                  <Checkbox className="tableCheckbox" />
                 </th>
                 <td>
                   <NodeKeyInput

--- a/ui-src/view/SimpleView.css
+++ b/ui-src/view/SimpleView.css
@@ -1,5 +1,5 @@
 .simple-view.simple-view {
-    flex-grow: 1;
-    /* Vertical align */
-    --flexLayout-justify: center;
+  flex-grow: 1;
+  /* Vertical align */
+  --flexLayout-justify: center;
 }

--- a/ui-src/view/SimpleView.css
+++ b/ui-src/view/SimpleView.css
@@ -1,0 +1,5 @@
+.simple-view.simple-view {
+    flex-grow: 1;
+    /* Vertical align */
+    --flexLayout-justify: center;
+}

--- a/ui-src/view/SimpleView.tsx
+++ b/ui-src/view/SimpleView.tsx
@@ -8,7 +8,9 @@ import {
 } from "../../shared-src";
 import { downloadDataUri } from "../components/utils";
 
-export const MainView = () => {
+import "./SimpleView.css";
+
+export const SimpleView = () => {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvLangs, setCsvLangs] = useState<string[]>([]);
   const [selectedLang, setSelectedLang] = useState<string>(DEFAULT_LANG);
@@ -101,7 +103,7 @@ export const MainView = () => {
   const revisionsAvailable = csvLangs.length > 0;
 
   return (
-    <StackLayout className="appRoot" align="center">
+    <StackLayout className="simple-view" align="center">
       <Button onClick={onExportCsv}>Export CSV</Button>
       {csvFile === null ? (
         <FileDropZone

--- a/ui-src/view/TabsView.tsx
+++ b/ui-src/view/TabsView.tsx
@@ -40,7 +40,7 @@ export const TabsView = () => {
           className="tab"
         >
           <Tab label="Basic" />
-          <Tab label="Advanced" />
+          <Tab label="Key Editable" />
         </Tabstrip>
       </FlexItem>
       {renderView()}

--- a/ui-src/view/TabsView.tsx
+++ b/ui-src/view/TabsView.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { FlexItem, StackLayout } from "@salt-ds/core";
+import { Tab, Tabstrip } from "@salt-ds/lab";
+import { SimpleView } from "./SimpleView";
+import { AdvancedView } from "./AdvancedView";
+
+export const TabsView = () => {
+  const [selectedTabIndex, setSelectedTabIndex] = useState(1);
+
+  const handleTabSelection = (index: number) => {
+    setSelectedTabIndex(index);
+    // parent.postMessage(
+    //   {
+    //     pluginMessage: {
+    //       type: "ui-view-changed",
+    //       view: index === 0 ? "select" : index === 1 ? "simple" : "advanced",
+    //     } as PostToFigmaMessage,
+    //   },
+    //   "*"
+    // );
+  };
+
+  const renderView = () => {
+    switch (selectedTabIndex) {
+      case 0:
+        return <SimpleView />;
+      case 1:
+        return <AdvancedView />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <StackLayout className="appRoot" gap={0}>
+      <FlexItem grow={0} shrink={0}>
+        <Tabstrip
+          activeTabIndex={selectedTabIndex}
+          onActiveChange={handleTabSelection}
+          className="tab"
+        >
+          <Tab label="Basic" />
+          <Tab label="Advanced" />
+        </Tabstrip>
+      </FlexItem>
+      {renderView()}
+    </StackLayout>
+  );
+};


### PR DESCRIPTION
Enables exporting copy to CSV/JSON with specified keys stored in Figma

In Figma, edit key and pick which text layer to export

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/5257855/210338591-86a806d0-56a1-4f90-82ed-56469cb9ed18.png">

CSV:

<img width="428" alt="image" src="https://user-images.githubusercontent.com/5257855/210340409-7ba5e437-fc41-460c-9ae6-15eec11762ca.png">

JSON:

<img width="695" alt="image" src="https://user-images.githubusercontent.com/5257855/210340496-20f0489b-8e68-45b1-ae08-0c8f5439da71.png">


## TODOs

- [x] Display text nodes key in table after scanning
- [x] Edit key to be stored as plugin data
- [x] CSV export
- [x] JSON export

Not included
- Instance / component key inheritance support
- Import to update, versioning 